### PR TITLE
remove asyncio as a dep since it's in python-core since 3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed"
 ]
-dependencies = ["asyncio", "aiohttp"]
+dependencies = ["aiohttp"]
 requires-python = ">=3.9"
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name = 'pyElectra',
     packages = ['electra'],
-    install_requires=['asyncio', 'aiohttp'],
+    install_requires=['aiohttp'],
     version = '0.1.1',
     description = 'A library to communicate with Electra Air Conditioners',
     author='Jafar Atili',


### PR DESCRIPTION
closes #1 

I didn't bump the version because I didn't know if you wanted to increment the patch or the minor. I can bump it if you want, or you can push it to my branch prior to merge.

Thanks