### PR TITLE
Fix issue with invalid registered devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,44 +9,51 @@ Python library to control Electra Smart Air Condtioiner devices
 Usage:
 
 ```python
+import sys
 import asyncio
 
 import aiohttp
 
-from electrasmart import *
+from electrasmart import api as electra_api
+from electrasmart.api import ElectraAPI
+from electrasmart.api.utils import generate_imei
+
+import logging
 
 
 async def main():
     session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False), timeout=aiohttp.ClientTimeout(total=10))
-    api = ElectraAPI(session)
 
     # User phone number
-    phone_number = "0521234567"
+    phone_number = input("Enter your account phone number: ")
     # Generate token
-    imei = generate_imei()
+    imei = electra_api.utils.generate_imei()
+    api = electra_api.ElectraAPI(session, phone_number=phone_number, imei=imei)
     try:
-        resp = await api.generate_new_token(phone_number=phone_number, imei=imei)
+        resp = await api.generate_new_token()
     except ElectraApiError as e:
         # handle error
         pass
 
-    otp = input("Enter the OTP you recieved via SMS")
+    otp = input("Enter the OTP you recieved via SMS: ")
     # more error handling
-    if resp[electra.ATTR_STATUS] == electra.STATUS_SUCCESS:
-        if resp[electra.ATTR_DATA][electra.ATTR_RES] != electra.STATUS_SUCCESS:
-            # Wrong phone number or unregistered user
+    if resp[electra_api.const.Attributes.STATUS] == electra_api.const.STATUS_SUCCESS:
+        if resp[electra_api.const.Attributes.DATA][electra_api.const.Attributes.RES] != electra_api.const.STATUS_SUCCESS:
+            print("Wrong phone number or unregistered user")
             sys.exit(1)
-     
-        resp = await api.validate_one_time_password(otp=otp, imei=imei, phone_number=phone_number)
-        if resp[electra.ATTR_DATA][electra.ATTR_RES] == electra.STATUS_SUCCESS:
-            token = resp[electra.ATTR_DATA][electra.ATTR_TOKEN]
+
+        resp = await api.validate_one_time_password(otp=otp)
+        if resp[electra_api.const.Attributes.DATA][electra_api.const.Attributes.RES] == electra_api.const.STATUS_SUCCESS:
+            token = resp[electra_api.const.Attributes.DATA][electra_api.const.Attributes.TOKEN]
         else:
-            # wrong OTP
+            print("wrong OTP")
             sys.exit(1)
-    
-    ac_devices = api.get_devices()
-    for ac in ac_devices:
-        assert(ac, ElectraAirConditioner)
+
+    await api.fetch_devices()
+    for ac in api.devices:
+        #assert(isinstance(ac, ElectraAirConditioner))
+        print(f"AC NAME: {ac.name}")
+        print(f"AC STATUS: {ac.status}")
         if ac.name == "Saloon AC":
             ac.turn_on()
             ac.set_mode(OPER_MODE_COOL)
@@ -56,7 +63,14 @@ async def main():
             api.set_state(ac)  # This will send the conf to the AC
 
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger('main').info("Started")
 
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(main())
+    except KeyboardInterrupt:
+        pass
 ```

--- a/src/electrasmart/api/__init__.py
+++ b/src/electrasmart/api/__init__.py
@@ -25,6 +25,7 @@ class ElectraAPI(object):
         self,
         websession: ClientSession,
         imei: str | None = None,
+        phone_number: str | None = None,
         token: str | None = None,
     ) -> None:
         self._base_url = "https://app.ecpiot.co.il/mobile/mobilecommand"
@@ -34,7 +35,7 @@ class ElectraAPI(object):
         self._sid_expiration = 0
         self._last_sid_request_ts = 0
         self._session = websession
-        self._phone_number = None
+        self._phone_number = phone_number
         self._devices: list[ElectraAirConditioner] = []
 
         logger.debug("Initialized Electra API object")
@@ -45,12 +46,14 @@ class ElectraAPI(object):
 
     async def _send_request(self, payload: dict[str, Any]) -> dict[str, Any]:
         try:
+            logger.debug(f"Sending request: {payload}")
             resp = await self._session.post(
                 url=self._base_url,
                 json=payload,
                 headers={"user-agent": "Electra Client"},
             )
             json_resp: dict[str, Any] = await resp.json(content_type=None)
+            logger.debug(f"Response: {json_resp}")
         except TimeoutError as ex:
             raise ElectraApiError(f"Failed to communicate with Electra API due to time out: ({str(ex)})")
         except ClientError as ex:
@@ -60,31 +63,36 @@ class ElectraAPI(object):
 
         return json_resp
 
-    async def generate_new_token(self, phone_number: str, imei: str) -> dict[str, Any]:
+    async def generate_new_token(self) -> dict[str, Any]:
         payload = {
             "pvdid": 1,
             "id": 99,
             "cmd": "SEND_OTP",
-            "data": {"imei": imei, "phone": phone_number},
+            "data": {"imei": self._imei, "phone": self._phone_number},
         }
 
-        return await self._send_request(payload=payload)
+        resp = await self._send_request(payload=payload)
+        return resp
 
-    async def validate_one_time_password(self, otp: str, imei: str, phone_number: str) -> dict[str, Any]:
+    async def validate_one_time_password(self, otp: str) -> dict[str, Any]:
         payload = {
             "pvdid": 1,
             "id": 99,
             "cmd": "CHECK_OTP",
             "data": {
-                "imei": imei,
-                "phone": phone_number,
+                "imei": self._imei,
+                "phone": self._phone_number,
                 "code": otp,
                 "os": "android",
                 "osver": "M4B30Z",
             },
         }
 
-        return await self._send_request(payload=payload)
+        resp = await self._send_request(payload=payload)
+        self._token = resp[const.Attributes.DATA][const.Attributes.TOKEN]
+        self._sid = resp[const.Attributes.DATA][const.Attributes.SID]
+        self._sid_expiration = int(datetime.now().timestamp()) + SID_EXPIRATION
+        return resp
 
     def _sid_expired(self) -> bool:
         current_time = int(datetime.now().timestamp())

--- a/src/electrasmart/api/__init__.py
+++ b/src/electrasmart/api/__init__.py
@@ -25,8 +25,8 @@ class ElectraAPI(object):
         self,
         websession: ClientSession,
         imei: str | None = None,
-        phone_number: str | None = None,
         token: str | None = None,
+        phone_number: str | None = None,
     ) -> None:
         self._base_url = "https://app.ecpiot.co.il/mobile/mobilecommand"
         self._sid = None
@@ -63,7 +63,12 @@ class ElectraAPI(object):
 
         return json_resp
 
-    async def generate_new_token(self) -> dict[str, Any]:
+    async def generate_new_token(self, phone_number: str | None = None, imei: str | None = None) -> dict[str, Any]:
+        if phone_number:
+            self._phone_number = phone_number
+        if imei:
+            self._imei = imei
+
         payload = {
             "pvdid": 1,
             "id": 99,
@@ -74,7 +79,12 @@ class ElectraAPI(object):
         resp = await self._send_request(payload=payload)
         return resp
 
-    async def validate_one_time_password(self, otp: str) -> dict[str, Any]:
+    async def validate_one_time_password(self, otp: str, imei: str | None = None, phone_number: str | None = None) -> dict[str, Any]:
+        if phone_number:
+            self._phone_number = phone_number
+        if imei:
+            self._imei = imei
+
         payload = {
             "pvdid": 1,
             "id": 99,

--- a/src/electrasmart/device/__init__.py
+++ b/src/electrasmart/device/__init__.py
@@ -120,6 +120,10 @@ class ElectraAirConditioner(object):
         return self._oper_data["SHABAT"] == OperationMode.ON
 
     def update_operation_states(self, data: dict[str, Any]) -> None:
+        if not (data and data['commandJson'] and data['commandJson']['OPER']):
+            logger.debug(f"Skipping update_operation_states due to erronous response: {data}")
+            return
+
         self._oper_data = json.loads(data["commandJson"]["OPER"])["OPER"]
         self._time_delta = data["timeDelta"]
         measurments = json.loads(data["commandJson"]["DIAG_L2"])["DIAG_L2"]

--- a/src/electrasmart/device/__init__.py
+++ b/src/electrasmart/device/__init__.py
@@ -1,9 +1,12 @@
+from logging import getLogger
 from __future__ import annotations
 
 import json
 from typing import Any
 
 from .const import Feature, OperationMode
+
+logger = getLogger(__name__)
 
 
 class ElectraAirConditioner(object):


### PR DESCRIPTION
This fix simply ignores the invalid status update for certain devices, which avoids failing to pull devices.

This is probably due to an AC being offline or in another failure state.

Additionally, this improves the API by maintaining internal state variables (such as `imei`, `phone_number`, `sid`, `token`, etc) when they're received, instead of relying on the user to maintain those. This does not break the current API, as arguments were made optional and always override existing values.

Lastly, this fixes the example snippet in README.md (which wasn't working due to API changed not being propagated as well as python deprecations).

This fixes issue #13 